### PR TITLE
support --merge-template during chalice-shrubbery deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chalice-shrubbery
 
-Chalic Shrubbery is a helper tool for automating AWS Chalice deployments using Cloud Formation.  Its purpose is to provide single-tool support for deploying Chalice microservices using AWS Cloud Formation (as opposed to using Chalice's built-it deploy function).
+Chalice Shrubbery is a helper tool for automating AWS Chalice deployments using Cloud Formation.  Its purpose is to provide single-tool support for deploying Chalice microservices using AWS Cloud Formation (as opposed to using Chalice's built-in deploy function).
 
 ## Installation
 
@@ -10,7 +10,7 @@ To install Chalice Shrubbery, use pip...
 pip install chalice-shrubbery
 ```
 
-Chalice Shrubbery requres both Chalice and the AWS CLI to be installed in the environment where it is used.  These are intentionally omitted from the requirements of this package.
+Chalice Shrubbery requires both Chalice and the AWS CLI to be installed in the environment where it is used.  These are intentionally omitted from the requirements of this package.
 
 Guidelines for getting started with Chalice are available here:
 

--- a/chalice_shrubbery_cli.py
+++ b/chalice_shrubbery_cli.py
@@ -92,7 +92,8 @@ def apply_transformations(chalice_template_file, stack_name):
 @click.command(help='Deploy a Chalice project to AWS using CloudFormation')
 @click.option('--stage', required=True, default='dev', help='Specify the Chalice stage to operate upon')
 @click.option('--profile', help='Provide the name of an AWS CLI profile to use for operations')
-def deploy(stage, profile):
+@click.option('--merge-template', default=None, help='Specify a JSON template to be merged into the generated template. This is useful for adding resources to a Chalice template or modify values in the template. CloudFormation Only.')
+def deploy(stage, profile, merge_template):
 
     if profile is not None:
         os.environ['AWS_PROFILE'] = profile
@@ -111,6 +112,15 @@ def deploy(stage, profile):
         '--stage', stage,
         chalice_package_output_folder
     ]
+
+    if merge_template:
+        chalice_command = [
+            'chalice', 'package',
+            '--stage', stage,
+            '--merge-template', merge_template,
+            chalice_package_output_folder
+        ]
+
     run_process('Using chalice to create deployment package template...', chalice_command)
 
     apply_transformations(chalice_template_file, stack_name)


### PR DESCRIPTION
Adds support for passing the path to a json cloudformation template to the [`--merge-template`](https://chalice.readthedocs.io/en/latest/topics/cfn.html#template-merge) argument of the `chalice package` command when using `chalice-shrubbery deploy`